### PR TITLE
Add LZR-inspired favicon

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#0a1424" />
+      <stop offset="70%" stop-color="#05070f" />
+      <stop offset="100%" stop-color="#020308" />
+    </radialGradient>
+    <radialGradient id="glow" cx="50%" cy="50%" r="60%">
+      <stop offset="30%" stop-color="rgba(103,200,255,0.7)" />
+      <stop offset="70%" stop-color="rgba(50,120,220,0.25)" />
+      <stop offset="100%" stop-color="rgba(10,30,80,0)" />
+    </radialGradient>
+    <linearGradient id="stroke" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#80f5ff" />
+      <stop offset="50%" stop-color="#60a8ff" />
+      <stop offset="100%" stop-color="#27d6ff" />
+    </linearGradient>
+    <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="16" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="512" height="512" fill="url(#bg)" />
+  <circle cx="256" cy="256" r="220" fill="url(#glow)" opacity="0.65" />
+  <circle cx="256" cy="256" r="190" fill="none" stroke="url(#stroke)" stroke-width="18" filter="url(#soft-glow)" />
+  <g filter="url(#soft-glow)" fill="none" stroke="url(#stroke)" stroke-width="24" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M148 340h88v-24h-60l64-120v-24h-92v24h64l-64 120z" fill="#0f1830" />
+    <path d="M254 340h112v-24h-84v-48h68v-24h-68v-48h84v-24H254z" fill="#0f1830" />
+    <path d="M412 316a24 24 0 0 1-24 24h-68v-24h64v-60l-64-84v-24h92v24h-64l64 84z" fill="#0f1830" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>LZRAY·主站 | Hub</title>
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
   <meta name="description" content="lzray.com 主站导航：Bulls & Cows、Translate100、Chat AI、WordMorph、Online24 等分站入口。" />
   
 <link rel="stylesheet" href="/fonts/style.css">


### PR DESCRIPTION
## Summary
- add an SVG favicon inspired by the LZR neon emblem
- reference the new favicon from the main HTML document

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d75ac7e2188333ad0ac9c6efbaf000